### PR TITLE
fix(blah-be): use config helper instead of env function

### DIFF
--- a/blah-be/app/Http/Controllers/OAuthProviderController.php
+++ b/blah-be/app/Http/Controllers/OAuthProviderController.php
@@ -44,7 +44,7 @@ class OAuthProviderController extends Controller
 
         Auth::login($user);
 
-        return redirect(env('FRONTEND_URL'));
+        return redirect(config('app.frontend_url'));
     }
 
     /**


### PR DESCRIPTION
**What type of PR is this?**
Fix: A bug fix

**What this PR does / why we need it:**
- use `redirect(config('app.frontend_url'));` instead of `redirect(env('FRONTEND_URL'));`

**Which issue(s) this PR fixes:**
- [#34](https://github.com/tiagomichaelsousa/website/issues/34)

**Special notes for your reviewer:**